### PR TITLE
[FEATURE]: Batch historical queries and adopt a slower ingestion time

### DIFF
--- a/src/indexer/historical.rs
+++ b/src/indexer/historical.rs
@@ -54,7 +54,7 @@ impl BlockGap {
             AND    time > (NOW() - ($2 || ' seconds')::INTERVAL)
         ) inner_alias
         WHERE height + 1 <> next_block
-        ORDER BY start_time DESC;
+        ORDER BY start_time ASC;
         "# }
         .trim()
     }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -174,10 +174,10 @@ pub async fn index_block_range(
 
         current_height += page_size;
 
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
     }
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     Ok(())
 }
@@ -318,7 +318,8 @@ pub async fn index_historical_blocks(
     db: &DatabaseConnection,
     filters: &[Filter],
 ) -> Result<()> {
-    let lookback_duration_in_secs = 60 * 60;
+    // TODO: Lookback 1 day for now.
+    let lookback_duration_in_secs = 60 * 60 * 24;
     let gaps = get_block_gaps(
         db,
         chain_id.to_string(),

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -7,7 +7,8 @@ use sea_orm::Set;
 use snafu::Snafu;
 use tendermint::abci;
 use tendermint_rpc::endpoint::tx;
-use tendermint_rpc::HttpClient;
+use tendermint_rpc::query::Query;
+use tendermint_rpc::{Client, HttpClient, Order};
 use tokio::time::timeout;
 use tokio_retry::strategy::{jitter, FibonacciBackoff};
 use tokio_retry::Retry;
@@ -142,6 +143,46 @@ impl TransactionModel {
 }
 
 ///
+/// Index a range of blocks into the database.
+///
+pub async fn index_block_range(
+    db: &DatabaseConnection,
+    rpc_client: &HttpClient,
+    filters: &[Filter],
+    start: i64,
+    end: i64,
+) -> Result<()> {
+    let page_size = 50;
+    let mut current_height = start;
+
+    for _ in 0..((end - start) / page_size) {
+        let blocks = rpc_client
+            .block_search(
+                Query::gte("block.height".to_string(), current_height)
+                    .and_lte("block.height", current_height + page_size),
+                1,
+                page_size as u8,
+                Order::Ascending,
+            )
+            .await?;
+        let blocks = blocks.blocks;
+
+        for block in blocks {
+            index_block(db, rpc_client, filters, block.block.into()).await?;
+            current_height += 1;
+        }
+
+        current_height += page_size;
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    Ok(())
+}
+
+///
 /// Index a block into the database.
 ///
 pub async fn index_block(
@@ -156,7 +197,7 @@ pub async fn index_block(
         Ok(block) => {
             // If we have transactions to index, do so.
             if block.num_txs > 0 {
-                let retry_strategy = FibonacciBackoff::from_millis(50).map(jitter).take(15);
+                let retry_strategy = FibonacciBackoff::from_millis(100).map(jitter).take(15);
 
                 // Retry the transaction query up to 10 times.
                 Retry::spawn(retry_strategy, || async {
@@ -277,7 +318,13 @@ pub async fn index_historical_blocks(
     db: &DatabaseConnection,
     filters: &[Filter],
 ) -> Result<()> {
-    let gaps = get_block_gaps(db, chain_id.to_string(), 7).await?;
+    let lookback_duration_in_secs = 60 * 60;
+    let gaps = get_block_gaps(
+        db,
+        chain_id.to_string(),
+        Duration::from_secs(lookback_duration_in_secs),
+    )
+    .await?;
 
     if gaps.is_empty() {
         info!("No gaps found, skipping historical block indexing");
@@ -285,19 +332,19 @@ pub async fn index_historical_blocks(
     }
 
     info!(
-        "Found {} gaps in block history for {} ({})",
+        "[{}] Found {} gaps in block history for ({})",
         name,
         chain_id,
         gaps.len()
     );
 
     for gap in gaps {
-        for range in gap {
-            let (start, end) = *range;
-            info!("Indexing gap blocks from {} to {}", start, end);
-            let block = rpc::get_block(rpc_client, start).await?;
-            index_block(db, rpc_client, filters, block.into()).await?;
-        }
+        info!(
+            "[{}] Indexing historical blocks for ({}) from {} to {}",
+            name, chain_id, gap.start, gap.end
+        );
+
+        index_block_range(db, rpc_client, filters, gap.start, gap.end).await?;
     }
 
     Ok(())

--- a/src/indexer/system.rs
+++ b/src/indexer/system.rs
@@ -44,7 +44,7 @@ pub async fn run(
             indexer::config::SourceType::Polling => {
                 last_polling_url = Some(source.url.clone());
                 provider_system
-                    .add_provider_stream(name, poll_stream_blocks(source.url.to_string(), 3));
+                    .add_provider_stream(name, poll_stream_blocks(source.url.to_string(), 4));
             }
         }
     }
@@ -148,7 +148,7 @@ pub async fn run_historical(
     // Historical indexing is done in a separate task.
     let historical_indexer_handle: JoinHandle<Result<()>> = tokio::spawn(async move {
         // Initially wait 30 seconds before checking historical gaps.
-        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
         let db = get_database_connection().await?;
         let last_polling_url = sources
@@ -166,7 +166,7 @@ pub async fn run_historical(
                     error!("[{}] Failed to index historical blocks: {}", name, err);
                     err
                 })?;
-            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
         }
     });
 

--- a/src/indexer/system.rs
+++ b/src/indexer/system.rs
@@ -192,7 +192,7 @@ pub async fn run_all() -> Result<()> {
     let mut indexer_handles = FuturesUnordered::new();
 
     for (path, config) in Config::get_configs_from_pwd()? {
-        info!("Starting indexer for {}: {}", config.name, path.display());
+        info!("[{}] Starting indexer: {}", config.name, path.display());
         trace!("Configuration details: {:#?}", config);
 
         let retry_strategy = FixedInterval::from_millis(5000);


### PR DESCRIPTION
Our old way of spamming the RPCs was making our providers not happy and they probably implemented some kind of load balancing.

Now we get historical batches in chunks and wait between each request to keep the providers happy!

Can other people try this out locally?